### PR TITLE
create ubuntu_only package list 

### DIFF
--- a/tasks/baseline.yml
+++ b/tasks/baseline.yml
@@ -6,6 +6,14 @@
     - "{{ baseline_packages }}"
     - "{{ baseline_packages_addons }}"
 
+- name: Adds packages for Ubuntu
+  apt:
+    pkg: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ ubuntu_only_packages }}"
+  when: ansible_distribution == 'Ubuntu'
+
 - name: Changes TZ
   file:
     state: link

--- a/tasks/baseline.yml
+++ b/tasks/baseline.yml
@@ -10,7 +10,7 @@
   apt:
     pkg: "{{ item.value }}"
     state: present
-  when: ansible_distribution == "{{ item.key }}"
+  when: ansible_distribution == item.key | lower
   with_dict: "{{ baseline_distribution_specific }}"
 
 - name: Changes TZ

--- a/tasks/baseline.yml
+++ b/tasks/baseline.yml
@@ -6,13 +6,12 @@
     - "{{ baseline_packages }}"
     - "{{ baseline_packages_addons }}"
 
-- name: Adds packages for Ubuntu
+- name: Adds distribution specific packages 
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item.value }}"
     state: present
-  with_items:
-    - "{{ ubuntu_only_packages }}"
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == "{{ item.key }}"
+  with_dict: "{{ baseline_distribution_specific }}"
 
 - name: Changes TZ
   file:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,5 +24,8 @@ baseline_packages:
     - moreutils
     - nmon
 
-ubuntu_only_packages:
-    - language-pack-fr-base
+baseline_distribution_specific:
+    Ubuntu:
+      - language-pack-fr-base
+    Debian:
+      - at

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,9 +18,11 @@ baseline_packages:
     - dnsutils
     - bmon
     - iptraf
-    - language-pack-fr-base
     - ncdu
     - ifupdown
     - httpie
     - moreutils
     - nmon
+
+ubuntu_only_packages:
+    - language-pack-fr-base


### PR DESCRIPTION
le package « language-pack-fr-base » n'existe pas dans Debian, donc la task « Adds few niceties » échoue sur les machines Debian.

- Création d'une liste `ubuntu_only_packages`
- Création d'une task qui installe les paquets de cette liste sur les machines où `ansible_distribution == 'Ubuntu'`
- Déplacement de `language-pack-fr-base` dans cette liste